### PR TITLE
Process architecture for Spotify API lookup / data cache

### DIFF
--- a/apps/spotify/.gitignore
+++ b/apps/spotify/.gitignore
@@ -1,0 +1,20 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/apps/spotify/README.md
+++ b/apps/spotify/README.md
@@ -1,0 +1,30 @@
+# Spotify
+
+Application to look and hold state from the Spotify API.
+
+One process will be created per artist lookup.
+
+```elixir
+
+iex()> artist_id = 303606909
+iex()> Spotify.ArtistSupervisor.find_or_create_process(artist_id)
+iex()> Spotify.Artist.details(artist_id)
+
+```
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `spotify` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:spotify, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/spotify](https://hexdocs.pm/spotify).

--- a/apps/spotify/config/config.exs
+++ b/apps/spotify/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# 3rd-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :spotify, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:spotify, :key)
+#
+# You can also configure a 3rd-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env}.exs"

--- a/apps/spotify/lib/spotify.ex
+++ b/apps/spotify/lib/spotify.ex
@@ -1,0 +1,14 @@
+defmodule Spotify do
+  @moduledoc """
+  Documentation for Spotify.
+  """
+  @doc """
+  Hello world.
+  ## Examples
+      iex> Spotify.hello
+      :world
+  """
+  def hello do
+    :world
+  end
+end

--- a/apps/spotify/lib/spotify/application.ex
+++ b/apps/spotify/lib/spotify/application.ex
@@ -1,0 +1,35 @@
+defmodule Spotify.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  # def start(_type, _args) do
+  #   # List all child processes to be supervised
+  #   children = [
+  #     # Starts a worker by calling: Spotify.Worker.start_link(arg)
+  #     # {Spotify.Worker, arg},
+  #   ]
+  #
+  #   # See https://hexdocs.pm/elixir/Supervisor.html
+  #   # for other strategies and supported options
+  #   opts = [strategy: :one_for_one, name: Spotify.Supervisor]
+  #   Supervisor.start_link(children, opts)
+  # end
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    # Define workers and child supervisors to be supervised
+    children = [
+      supervisor(Registry, [:unique, :spotify_process_registry]),
+      supervisor(Spotify.ArtistSupervisor, [])
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Spotify.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/spotify/lib/spotify/artist.ex
+++ b/apps/spotify/lib/spotify/artist.ex
@@ -1,0 +1,175 @@
+defmodule Spotify.Artist do
+  @moduledoc """
+  Simple genserver to represent an imaginary artist process.
+
+  Requires you provide an integer-based `artist_id` upon starting.
+
+  There is a `:fetch_data` callback handler where you could easily get additional artist attributes
+  from a database or some other source - assuming the `artist_id` provided was a valid key to use as
+  database criteria.
+  """
+
+  use GenServer
+  require Logger
+
+  @artist_registry_name :spotify_process_registry
+  @process_lifetime_ms 86_400_000 # 24 hours in milliseconds - make this number shorter to experiement with process termination
+
+  # Just a simple struct to manage the state for this genserver
+  # You could add additional attributes here to keep track of for a given artist
+  defstruct artist_id: 0,
+            name: "",
+            some_attribute: "",
+            widgets_ordered: 1,
+            timer_ref: nil
+
+
+  @doc """
+  Starts a new artist process for a given `artist_id`.
+  """
+  def start_link(artist_id) when is_integer(artist_id) do
+    IO.puts "Artist.start_link(#{artist_id})----------->"
+    GenServer.start_link(__MODULE__, [artist_id], name: via_tuple(artist_id))
+  end
+
+
+  # registry lookup handler
+  defp via_tuple(artist_id), do: {:via, Registry, {@artist_registry_name, artist_id}}
+
+
+  @doc """
+  Return some details (state) for this artist process
+  """
+  def details(artist_id) do
+    GenServer.call(via_tuple(artist_id), :get_details)
+  end
+
+
+  @doc """
+  Return the number of widgets ordered by this artist
+  """
+  def widgets_ordered(artist_id) do
+    GenServer.call(via_tuple(artist_id), :get_widgets_ordered)
+  end
+
+
+  @doc """
+  Function to indicate that this artist ordered a widget
+  """
+  def order_widget(artist_id) do
+    GenServer.call(via_tuple(artist_id), :order_widget)
+  end
+
+
+  @doc """
+  Returns the pid for the `artist_id` stored in the registry
+  """
+  def whereis(artist_id) do
+    case Registry.lookup(@artist_registry_name, artist_id) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+
+  @doc """
+  Init callback
+  """
+  def init([artist_id]) do
+
+    # Add a msg to the process mailbox to
+    # tell this process to run `:fetch_data`
+    send(self(), :fetch_data)
+    send(self(), :set_terminate_timer)
+
+    IO.puts("Process created... Artist ID: #{artist_id}")
+
+    # Set initial state and return from `init`
+    {:ok, %__MODULE__{ artist_id: artist_id }}
+  end
+
+
+  @doc """
+  Our imaginary callback handler to get some data from a DB to
+  update the state on this process.
+  """
+  def handle_info(:fetch_data, state) do
+
+    # update the state from the DB in imaginary land. Hardcoded for now.
+    updated_state =
+      %__MODULE__{ state | widgets_ordered: 1, name: "Artist foo" }
+      # %__MODULE__{ state | widgets_ordered: 1, name: "Artist #{artist_id}" }
+
+    {:noreply, updated_state}
+  end
+
+  @doc """
+  Callback handler that sets a timer for 24 hours to terminate this process.
+
+  You can call this more than once it will continue to `push out` the timer (and cleans up the previous one)
+
+  I could have combined the logic below and used just one callback handler, but I like seperating the
+  concern of creating an initial timer reference versus destroying an existing one. But that is up to you.
+  """
+  def handle_info(:set_terminate_timer, %__MODULE__{ timer_ref: nil } = state) do
+    # This is the first time we've dealt with this artist, so lets set our timer reference attribute
+    # to end this process in 24 hours from now
+
+    # set a timer for 24 hours from now to end this process
+    updated_state =
+      %__MODULE__{ state | timer_ref: Process.send_after(self(), :end_process, @process_lifetime_ms) }
+
+    {:noreply, updated_state}
+  end
+
+  def handle_info(:set_terminate_timer, %__MODULE__{ timer_ref: timer_ref } = state) do
+    # This match indicates we are in a situation where `state.timer_ref` is not nil -
+    # so we already have dealt with this artist before
+
+    # let's cancel the existing timer
+    timer_ref |> Process.cancel_timer
+
+    # set a new timer for 24 hours from now to end this process
+    updated_state =
+      %__MODULE__{ state | timer_ref: Process.send_after(self(), :end_process, @process_lifetime_ms) }
+
+    {:noreply, updated_state}
+  end
+
+
+  @doc """
+  Gracefully end this process
+  """
+  def handle_info(:end_process, state) do
+    Logger.info("Process terminating... Artist ID: #{state.artist_id}")
+    {:stop, :normal, state}
+  end
+
+
+  @doc false
+  def handle_call(:get_details, _from, state) do
+
+    # maybe you'd want to transform the state a bit...
+    response = %{
+      id: state.artist_id,
+      name: state.name,
+      some_attribute: state.some_attribute,
+      widgets_ordered: state.widgets_ordered
+    }
+
+    {:reply, response, state}
+  end
+
+
+  @doc false
+  def handle_call(:get_widgets_ordered, _from, %__MODULE__{ widgets_ordered: widgets_ordered } = state) do
+    {:reply, widgets_ordered, state}
+  end
+
+
+  @doc false
+  def handle_call(:order_widget, _from, %__MODULE__{ widgets_ordered: widgets_ordered } = state) do
+    {:reply, :ok, %__MODULE__{ state | widgets_ordered: widgets_ordered + 1 }}
+  end
+
+end

--- a/apps/spotify/lib/spotify/artist_supervisor.ex
+++ b/apps/spotify/lib/spotify/artist_supervisor.ex
@@ -1,0 +1,125 @@
+defmodule Spotify.ArtistSupervisor do
+  @moduledoc """
+  Supervisor to handle the creation of dynamic `Spotify.Artist` processes using a
+  `simple_one_for_one` strategy. See the `init` callback at the bottom for details on that.
+
+  These processes will spawn for each `artist_id` provided to the
+  `Spotify.Artist.start_link` function.
+
+  Functions contained in this supervisor module will assist in the creation and retrieval of
+  new artist processes.
+
+  Also note the guards utilizing `is_integer(artist_id)` on the functions. My feeling here is that
+  if someone makes a mistake and tries sending a string-based key or an atom, I'll just _"let it crash"_.
+  """
+
+  use Supervisor
+  require Logger
+
+
+  @artists_registry_name :spotify_process_registry
+
+  @doc """
+  Starts the supervisor.
+  """
+  def start_link, do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+
+
+  @doc """
+  Will find the process identifier (in our case, the `artist_id`) if it exists in the registry and
+  is attached to a running `Spotify.Artist` process.
+
+  If the `artist_id` is not present in the registry, it will create a new `Spotify.Artist`
+  process and add it to the registry for the given `artist_id`.
+
+  Returns a tuple such as `{:ok, artist_id}` or `{:error, reason}`
+  """
+  def find_or_create_process(artist_id) when is_integer(artist_id) do
+    if artist_process_exists?(artist_id) do
+      {:ok, artist_id}
+    else
+      artist_id |> create_artist_process
+    end
+  end
+
+
+  @doc """
+  Determines if a `Spotify.Artist` process exists, based on the `artist_id` provided.
+
+  Returns a boolean.
+
+  ## Example
+      iex> Spotify.ArtistSupervisor.artist_process_exists?(6)
+      false
+  """
+  def artist_process_exists?(artist_id) when is_integer(artist_id) do
+    case Registry.lookup(@artists_registry_name, artist_id) do
+      [] -> false
+      _ -> true
+    end
+  end
+
+
+  @doc """
+  Creates a new Artist process, based on the `artist_id` integer.
+
+  Returns a tuple such as `{:ok, artist_id}` if successful.
+  If there is an issue, an `{:error, reason}` tuple is returned.
+  """
+  def create_artist_process(artist_id) when is_integer(artist_id) do
+    case Supervisor.start_child(__MODULE__, [artist_id]) do
+      {:ok, _pid} -> {:ok, artist_id}
+      {:error, {:already_started, _pid}} -> {:error, :process_already_exists}
+      other -> {:error, other}
+    end
+  end
+
+
+  @doc """
+  Returns the count of `Spotify.Artist` processes managed by this supervisor.
+
+  ## Example
+      iex> Spotify.ArtistSupervisor.artist_process_count
+      0
+  """
+  def artist_process_count, do: Supervisor.which_children(__MODULE__) |> length
+
+
+  @doc """
+  Return a list of `artist_id` integers known by the registry.
+
+  ex - `[1, 23, 46]`
+  """
+  def artist_ids do
+    Supervisor.which_children(__MODULE__)
+    |> Enum.map(fn {_, artist_proc_pid, _, _} ->
+      Registry.keys(@artists_registry_name, artist_proc_pid)
+      |> List.first
+    end)
+    |> Enum.sort
+  end
+
+
+  @doc """
+  Return a list of widgets ordered per artist.
+
+  The list will be made up of a map structure for each child artist process.
+
+  ex - `[%{artist_id: 2, widgets_sold: 1}, %{artist_id: 10, widgets_sold: 1}]`
+  """
+  def get_all_artist_widgets_ordered do
+    artist_ids() |> Enum.map(&(%{ artist_id: &1, widgets_sold: Spotify.Artist.widgets_ordered(&1) }))
+  end
+
+
+  @doc false
+  def init(_) do
+    children = [
+      worker(Spotify.Artist, [], restart: :temporary)
+    ]
+
+    # strategy set to `:simple_one_for_one` to handle dynamic child processes.
+    supervise(children, strategy: :simple_one_for_one)
+  end
+
+end

--- a/apps/spotify/lib/spotify/supervisor.ex
+++ b/apps/spotify/lib/spotify/supervisor.ex
@@ -1,0 +1,15 @@
+defmodule Spotify.Supervisor do
+  use Supervisor
+
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_opts) do
+    children = [
+      worker(Spotify, [], restart: :temporary)
+    ]
+
+    supervise children, strategy: :simple_one_for_one
+  end
+end

--- a/apps/spotify/mix.exs
+++ b/apps/spotify/mix.exs
@@ -1,0 +1,34 @@
+defmodule Spotify.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :spotify,
+      version: "0.1.0",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.5",
+      start_permanent: Mix.env == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {Spotify.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      # {:sibling_app_in_umbrella, in_umbrella: true},
+    ]
+  end
+end

--- a/apps/spotify/test/spotify_test.exs
+++ b/apps/spotify/test/spotify_test.exs
@@ -1,0 +1,8 @@
+defmodule SpotifyTest do
+  use ExUnit.Case
+  doctest Spotify
+
+  test "greets the world" do
+    assert Spotify.hello() == :world
+  end
+end

--- a/apps/spotify/test/test_helper.exs
+++ b/apps/spotify/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Kicking the tyres for a general purpose pattern that can be followed for other Data Sources.

Starting with a Spotify lookup and will see if we can extrapolate.

Based up this Registry example: https://medium.com/elixirlabs/registry-in-elixir-1-4-0-d6750fb5aeb